### PR TITLE
Bake jq alongside apprise into Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,13 @@
 FROM python:3
 
-RUN pip install apprise j2cli
+RUN set -x \
+    \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends jq \
+    && rm -rf /var/lib/apt/lists/* \
+    \
+    && pip install --no-cache-dir apprise j2cli
+
 COPY entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT [ "/entrypoint.sh" ]


### PR DESCRIPTION
Following what is stated on #8, I am baking jq binary alongside apprise. Please let me know if there is any issue with this approach.

Happy hacking :octocat: 