### PR TITLE
Pin python to 3.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.11
 
 RUN set -x \
     \


### PR DESCRIPTION
Unfortunately python 3.12 drops the module `imp` which is needed by j2cli.
Update j2cli to do not use the `imp` module seems to be non-trivial (see https://github.com/kolypto/j2cli/issues/80 for more details)

So the simplest fix would be to pin the python version to 3.11 